### PR TITLE
Modify $query_url to use Version 1 for Backdrop projects.

### DIFF
--- a/project_browser.inc
+++ b/project_browser.inc
@@ -480,7 +480,7 @@ function project_browser_fetch_results($filters) {
         $local_filters['categories'] = serialize($local_filters['categories']);
       }
 
-			$query_url = $url . '/query/' . $local_filters['type'] . '/7?' . http_build_query($local_filters, FALSE, '&');
+      $query_url = $url . '/query/' . $local_filters['type'] . '/1?' . http_build_query($local_filters, FALSE, '&');
       $response = backdrop_http_request($query_url);
       if ($response->code == '200') {
         $results_raw = backdrop_json_decode($response->data);


### PR DESCRIPTION
This URL gets data about projects from project_browser_server, wherever that may be.
The version number for Backdrop or Drupal seems to be included in the main url as well as in the query string.
